### PR TITLE
Update README.md - add dependecies badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # shopify-clj
 
+
+[![Dependencies Status](https://jarkeeper.com/jamesmacaulay/shopify-clj/status.png)](https://jarkeeper.com/jamesmacaulay/shopify-clj)
+
 A [Clojure][clojure] library for interacting with the [Shopify][shopify] platform.
 
 * `shopify.resources`: functions for interacting with [a shop's resources][resource-docs].


### PR DESCRIPTION
Hi,

I made site for viewing status of Clojure project dependencies - http://jarkeeper.com/jamesmacaulay/shopify-clj.

Basically this pull request adds badge with the status of the dependencies in shopify-clj. It's quite useful for people who search for library to use. They can see if the project is well maintained.

What is your opinion about it?
